### PR TITLE
Build 7.4 & 8.3 explicitly

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,34 +17,34 @@ jobs:
       matrix:
         include:
           - baseImageTag: 7.4
-            imageTag: 7.x
+            imageTag: 7.4
           - baseImageTag: 7.4
-            imageTag: 7.x-debug
+            imageTag: 7.4-debug
             xdebugVersion: '3.1.6'
           - baseImageTag: 7.4-apache
-            imageTag: 7.x-apache
+            imageTag: 7.4-apache
           - baseImageTag: 7.4-apache
-            imageTag: 7.x-apache-debug
+            imageTag: 7.4-apache-debug
             xdebugVersion: '3.1.6'
           - baseImageTag: 7.4-fpm
-            imageTag: 7.x-fpm
+            imageTag: 7.4-fpm
           - baseImageTag: 7.4-fpm
-            imageTag: 7.x-fpm-debug
+            imageTag: 7.4-fpm-debug
             xdebugVersion: '3.1.6'
-          - baseImageTag: 8.2
-            imageTag: 8.x
-          - baseImageTag: 8.2
-            imageTag: 8.x-debug
+          - baseImageTag: 8.3
+            imageTag: 8.3
+          - baseImageTag: 8.3
+            imageTag: 8.3-debug
             xdebugVersion: '3.2.2'
-          - baseImageTag: 8.2-apache
-            imageTag: 8.x-apache
-          - baseImageTag: 8.2-apache
-            imageTag: 8.x-apache-debug
+          - baseImageTag: 8.3-apache
+            imageTag: 8.3-apache
+          - baseImageTag: 8.3-apache
+            imageTag: 8.3-apache-debug
             xdebugVersion: '3.2.2'
-          - baseImageTag: 8.2-fpm
-            imageTag: 8.x-fpm
-          - baseImageTag: 8.2-fpm
-            imageTag: 8.x-fpm-debug
+          - baseImageTag: 8.3-fpm
+            imageTag: 8.3-fpm
+          - baseImageTag: 8.3-fpm
+            imageTag: 8.3-fpm-debug
             xdebugVersion: '3.2.2'
 
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ To use this image, you must have [Docker](https://www.docker.com) installed.
 ### Inside your [Dockerfile](https://docs.docker.com/engine/reference/builder/#from)
 
 ```dockerfile
-# you can use any of 7.x, 7.x-apache, 7.x-fpm, 8.x, 8.x-apache or 8.x-fpm as image tag
-# can suffix tag with -debug for an image with xdebug e.g., php-8.x-debug
-FROM ghcr.io/qrstuff/phackage:7.x
+# you can use any of 7.4, 7.4-apache, 7.4-fpm, 8.3, 8.3-apache or 8.3-fpm as image tag
+# can suffix tag with -debug for an image with xdebug e.g., php-8.3-debug
+FROM ghcr.io/qrstuff/phackage:7.4
 
 # ...run, cmd & more
 ```
@@ -21,11 +21,11 @@ FROM ghcr.io/qrstuff/phackage:7.x
 ### Directly with `docker run`
 
 ```shell
-# you can use any of 7.x, 7.x-apache, 7.x-fpm, 8.x, 8.x-apache or 8.x-fpm as image tag
-# again, can suffix tag with -debug for an image with xdebug e.g., php-8.x-debug
-$ docker run -it --rm -v .:/app -w /app ghcr.io/qrstuff/phackage:7.x composer install
+# you can use any of 7.4, 7.4-apache, 7.4-fpm, 8.3, 8.3-apache or 8.3-fpm as image tag
+# again, can suffix tag with -debug for an image with xdebug e.g., php-8.3-debug
+$ docker run -it --rm -v .:/app -w /app ghcr.io/qrstuff/phackage:7.4 composer install
 
-$ docker run -it -p 8000:8000 --rm -v .:/app -w /app ghcr.io/qrstuff/phackage:7.x php artisan serve
+$ docker run -it -p 8000:8000 --rm -v .:/app -w /app ghcr.io/qrstuff/phackage:7.4 php artisan serve
 ```
 
 ## Building


### PR DESCRIPTION
Instead of 7.x or 8.x tags, use explicit tags.